### PR TITLE
Standardize JSON format across experiments

### DIFF
--- a/static/posner/js/posner.js
+++ b/static/posner/js/posner.js
@@ -33,6 +33,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   const cornerSquareElement = document.getElementById('corner-square');
 
+  // Collected trial data will be stored here to send to the server
+  let trialDataArray = [];
+
   console.log("Page elements initialized.");
 
 
@@ -68,12 +71,20 @@ document.addEventListener('DOMContentLoaded', async () => {
         
         const trialOrder = generateTrialOrder();
 
-        let trial_colors = []
+        let trial_colors = [];
+        trialDataArray = [];
 
         experimentUUID = generateUUID(); // From utils.js
         for (let i = 0; i < TOTAL_TRIALS; i++) {
-          trial_colors.push([trialOrder[0][i] ? 'orange' : 'blue',
-                             trialOrder[1][i] ? 'orange' : 'blue']);
+          const leftColor = trialOrder[0][i] ? 'orange' : 'blue';
+          const rightColor = trialOrder[1][i] ? 'orange' : 'blue';
+          trial_colors.push([leftColor, rightColor]);
+          trialDataArray.push({
+            trial_number: i + 1,
+            left_dot_color: leftColor,
+            right_dot_color: rightColor,
+            dot_delay_ms: null
+          });
         }
 
         const sessionGroup = getQueryParam('SG');
@@ -98,8 +109,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         cornerSquareElement.classList.add('hidden');
 
-        // Send session data to server
-        await sendDataToServer(sessionData, experimentUUID, "posner");
+        // Send data to server in a consistent format
+        const dataToSend = {
+          session: sessionData,
+          trials: trialDataArray
+        };
+        await sendDataToServer(dataToSend, experimentUUID, "posner");
         
     } else {
         console.error("Required elements for fixation cross not found.");
@@ -146,6 +161,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
       // Wait random dot delay (500-1000ms)
       const dotDelay = Math.random() * 500 + 500;
+      trialDataArray[count].dot_delay_ms = Math.round(dotDelay);
       await new Promise(r => setTimeout(r, dotDelay));
   
       // Show dots and corner square

--- a/static/squeeze/js/squeeze.js
+++ b/static/squeeze/js/squeeze.js
@@ -279,12 +279,12 @@ document.addEventListener('DOMContentLoaded', () => {
             if (cornerSquareElement) cornerSquareElement.style.visibility = 'hidden';
             
             // Send data to server
-            const finalDataPayload = {
-                session_info: sessionData,
-                trial_data: allTrialsData
+            const finalData = {
+                session: sessionData,
+                trials: allTrialsData
             };
-            sendDataToServer(finalDataPayload, experimentUUID, 'squeeze'); // from utils.js
-            console.log("Final data payload for debugging:", finalDataPayload);
+            sendDataToServer(finalData, experimentUUID, 'squeeze'); // from utils.js
+            console.log("Final data payload for debugging:", finalData);
             console.log("Data sending process initiated.");
         }
     }


### PR DESCRIPTION
## Summary
- capture trial data in posner experiment
- send session/trial objects from posner
- use common `session`/`trials` keys for squeeze data
- record random dot delay for each Posner trial

## Testing
- `bash describe.sh` *(fails: tree missing)*